### PR TITLE
Added try-catch around super call to identify errors when inputting d…

### DIFF
--- a/src/resume_schemas/resume.py
+++ b/src/resume_schemas/resume.py
@@ -115,7 +115,12 @@ class Resume(BaseModel):
                         ed['exam'] = self.normalize_exam_format(ed['exam'])
 
             # Create an instance of Resume from the parsed data
-            super().__init__(**data)
+            try:
+                super().__init__(**data)
+            except Exception as e:
+                print(f"Error in super call: {e}")
+                raise
+
         except yaml.YAMLError as e:
             raise ValueError("Error parsing YAML file.") from e
         except Exception as e:


### PR DESCRIPTION
…ata. Fixes bot not running

The error for when the bot does not start is usually an issue with data inputted into plain_text_resume.yaml. To identify these errors, a try-catch was placed around the super call for the Resume class in resume.py. This fixed the issue by allowing the user to see what exactly they inputted wrong and what to fix.